### PR TITLE
Fix /game asset loading under subpath (base href)

### DIFF
--- a/public/game/index.html
+++ b/public/game/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8">
+		<base href="/game/">
 		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0">
 		<title>Piggy City</title>
 		<style>


### PR DESCRIPTION
Adds a base href tag so the Godot shell relative assets resolve under /game/ even when Vercel serves the page at /game (no trailing slash). Without it, /game/ and /game returned 404 on index.js and the engine never booted; only /game/index.html worked. Verified in a headless browser. Scoped to public/game/index.html only; does not touch React.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the game page so relative links and resources resolve correctly when accessed from the `/game/` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->